### PR TITLE
Force `cdls` to use the `builtin` version of `cd`

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -5,9 +5,9 @@ alias n='nautilus'
 
 cdls() {
    if [ -z "$1" ]; then
-       cd && ls
+       builtin cd && ls
    else
-       cd "$*" && ls  
+       builtin cd "$*" && ls  
    fi  
 }
 alias cd=cdls


### PR DESCRIPTION
An issue arises if you `source` your `.bashrc` after you enter your login shell (and thus it gets sourced). This is because when your login shell sources your `.bashrc`, `cd` now becomes `cdls`. When you try sourcing again post-login (e.g. you change/add/remove an alias/environment variable/etc.), you now have a function that looks like

``` bash
cdls() {
   if [ -z "$1" ]; then
       cdls && ls
   else
       cdls "$*" && ls  
   fi  
}
```

and therefore you end up recursing until `bash` segfaults.

The fix forces `bash` to always use the `builtin` version of `cd` within `cdls`, thereby circumventing the problem.
